### PR TITLE
Bump terraform-provider-frontegg to 0.2.35 for auth_strategy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/MaterializeInc/pulumi-frontegg
 
 go 1.16
 
-replace github.com/frontegg/terraform-provider-frontegg => github.com/frontegg/terraform-provider-frontegg v0.2.33
+replace github.com/frontegg/terraform-provider-frontegg => github.com/frontegg/terraform-provider-frontegg v0.2.35
 
 replace (
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
-github.com/frontegg/terraform-provider-frontegg v0.2.33 h1:kbQeviZYx6saVpPZKHx+UsEKCF/OPcxUfFq2aggFN80=
-github.com/frontegg/terraform-provider-frontegg v0.2.33/go.mod h1:SeODoH1VhtAkRSMUGHGA+0+orI7Ktpo0eyvLHtbJHcc=
+github.com/frontegg/terraform-provider-frontegg v0.2.35 h1:1/N4nlXoMYVUSimo9fPc9ziYoK63MtMocpQvY8HmXOo=
+github.com/frontegg/terraform-provider-frontegg v0.2.35/go.mod h1:WHC7imTo0r8I7ZJ//SpPU6vU//Rqm6ibVdzgxpbejq4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=


### PR DESCRIPTION
This pulls in https://github.com/frontegg/terraform-provider-frontegg/releases/tag/v0.2.35, which makes it possible to specify that a workspace should use username/password vs. email-me-a-code authentication.