### PR TITLE
bump frontegg tf provider to 0.2.45

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MaterializeInc/pulumi-frontegg
 go 1.20
 
 require (
-	github.com/frontegg/terraform-provider-frontegg v0.2.44
+	github.com/frontegg/terraform-provider-frontegg v0.2.45
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.47.0
 	github.com/pulumi/pulumi/sdk/v3 v3.68.0
 	golang.org/x/mod v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -753,6 +753,8 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frontegg/terraform-provider-frontegg v0.2.44 h1:bTCRdxajkSiFYPyPg77ASzowj380D4AN4+kmFeRRWSM=
 github.com/frontegg/terraform-provider-frontegg v0.2.44/go.mod h1:QuKq3Cny4RkHttOav+o4B0WhP6oFY0nTUhAW6pNdvbk=
+github.com/frontegg/terraform-provider-frontegg v0.2.45 h1:Nl9sWOQivKOQs0xIUxaM+60BV1DxvjDUOTQy3z23JMs=
+github.com/frontegg/terraform-provider-frontegg v0.2.45/go.mod h1:QuKq3Cny4RkHttOav+o4B0WhP6oFY0nTUhAW6pNdvbk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
@@ -1610,6 +1612,7 @@ github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFz
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 h1:Qj1ukM4GlMWXNdMBuXcXfz/Kw9s1qm0CLY32QxuSImI=
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Bumping provider to fix webhook deletion error
https://github.com/frontegg/terraform-provider-frontegg/issues/103



updated go.mod and ran make