### PR TITLE
update upstream tf provider to v0.2.48

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MaterializeInc/pulumi-frontegg
 go 1.20
 
 require (
-	github.com/frontegg/terraform-provider-frontegg v0.2.45
+	github.com/frontegg/terraform-provider-frontegg v0.2.48
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.47.0
 	github.com/pulumi/pulumi/sdk/v3 v3.68.0
 	golang.org/x/mod v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -755,6 +755,7 @@ github.com/frontegg/terraform-provider-frontegg v0.2.44 h1:bTCRdxajkSiFYPyPg77AS
 github.com/frontegg/terraform-provider-frontegg v0.2.44/go.mod h1:QuKq3Cny4RkHttOav+o4B0WhP6oFY0nTUhAW6pNdvbk=
 github.com/frontegg/terraform-provider-frontegg v0.2.45 h1:Nl9sWOQivKOQs0xIUxaM+60BV1DxvjDUOTQy3z23JMs=
 github.com/frontegg/terraform-provider-frontegg v0.2.45/go.mod h1:QuKq3Cny4RkHttOav+o4B0WhP6oFY0nTUhAW6pNdvbk=
+github.com/frontegg/terraform-provider-frontegg v0.2.48/go.mod h1:exy6mBadqMexnaODaXdUUF/AkkqzcNpfVau7u62+8HE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=


### PR DESCRIPTION
Notable new features
>Allow configuration of OIDC redirect URL by @benesch in https://github.com/frontegg/terraform-provider-frontegg/pull/114

https://github.com/frontegg/terraform-provider-frontegg/releases](https://github.com/frontegg/terraform-provider-frontegg/releases/tag/v0.2.48)