### PR TITLE
updates the go.sum for the fe tf provider

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -755,6 +755,7 @@ github.com/frontegg/terraform-provider-frontegg v0.2.44 h1:bTCRdxajkSiFYPyPg77AS
 github.com/frontegg/terraform-provider-frontegg v0.2.44/go.mod h1:QuKq3Cny4RkHttOav+o4B0WhP6oFY0nTUhAW6pNdvbk=
 github.com/frontegg/terraform-provider-frontegg v0.2.45 h1:Nl9sWOQivKOQs0xIUxaM+60BV1DxvjDUOTQy3z23JMs=
 github.com/frontegg/terraform-provider-frontegg v0.2.45/go.mod h1:QuKq3Cny4RkHttOav+o4B0WhP6oFY0nTUhAW6pNdvbk=
+github.com/frontegg/terraform-provider-frontegg v0.2.48 h1:1J9NwVWeXeIAxCIyb70dB9opM/EFPjEz7tmSa8mfmOU=
 github.com/frontegg/terraform-provider-frontegg v0.2.48/go.mod h1:exy6mBadqMexnaODaXdUUF/AkkqzcNpfVau7u62+8HE=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
I have no idea how https://github.com/MaterializeInc/pulumi-frontegg/pull/9 had an incorrect go.sum.  