### PR TITLE
Bump frontegg provider to v0.2.52

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230912190043-e6d96b3b8f7e
 
 require (
-	github.com/frontegg/terraform-provider-frontegg v0.2.51
+	github.com/frontegg/terraform-provider-frontegg v0.2.52
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.63.0
 	github.com/pulumi/pulumi/sdk/v3 v3.91.1
 	golang.org/x/mod v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -1197,6 +1197,8 @@ github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frontegg/terraform-provider-frontegg v0.2.51 h1:pQQ4mkZq7IPoAei8pDFfmwBq4YBf8g9nFo6k9p5w6as=
 github.com/frontegg/terraform-provider-frontegg v0.2.51/go.mod h1:qF+TgXD8Ex/xlgWJKvNitYIu6fKsv/CMpXrbW7WEJgk=
+github.com/frontegg/terraform-provider-frontegg v0.2.52 h1:IYgOCJi62xczMfIqRiEqqfJfr2vvcnGqJJWR7a/FCVo=
+github.com/frontegg/terraform-provider-frontegg v0.2.52/go.mod h1:qF+TgXD8Ex/xlgWJKvNitYIu6fKsv/CMpXrbW7WEJgk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=


### PR DESCRIPTION
https://github.com/frontegg/terraform-provider-frontegg/releases/tag/v0.2.52