### PR TITLE
bump our tf provider fork to pick up email template additions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraf
 // https://github.com/MaterializeInc/terraform-provider-frontegg/pull/1
 // remove when the above pr is merged upstream.
 
-replace github.com/frontegg/terraform-provider-frontegg => github.com/MaterializeInc/terraform-provider-frontegg v0.0.0-20240221202139-490d32ed6136
+replace github.com/frontegg/terraform-provider-frontegg => github.com/MaterializeInc/terraform-provider-frontegg v0.0.0-20240402203558-024adfb650ed
 
 require (
 	github.com/frontegg/terraform-provider-frontegg v0.2.57

--- a/go.sum
+++ b/go.sum
@@ -708,8 +708,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
 github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
-github.com/MaterializeInc/terraform-provider-frontegg v0.0.0-20240221202139-490d32ed6136 h1:06JqxoOQOqs0fWampKfS+GJ2d7OcqWCFjNjzf6BbV9c=
-github.com/MaterializeInc/terraform-provider-frontegg v0.0.0-20240221202139-490d32ed6136/go.mod h1:mDCJsEfzRsTc3OgZOd/JFvX42uK4yHUmd/RVwoivTww=
+github.com/MaterializeInc/terraform-provider-frontegg v0.0.0-20240402203558-024adfb650ed h1:PNl62lkULdtR4QHtFUIIlCNcibH3y+k8834YP/9DZys=
+github.com/MaterializeInc/terraform-provider-frontegg v0.0.0-20240402203558-024adfb650ed/go.mod h1:mDCJsEfzRsTc3OgZOd/JFvX42uK4yHUmd/RVwoivTww=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=


### PR DESCRIPTION
our tf provider branch has been bumped: https://github.com/MaterializeInc/terraform-provider-frontegg/commits/pinned/0.2.57/

The new pseudo-version is from:

```
go mod edit -replace github.com/frontegg/terraform-provider-frontegg=github.com/MaterializeInc/terraform-provider-frontegg@024adfb650eddb6a1bc69f9f30e202d56946d9e2 && go mod tidy
```